### PR TITLE
fix: getPublicIpIdNameMapping use wrong vpcClient.ResourceBase

### DIFF
--- a/internal/otc_wrapper.go
+++ b/internal/otc_wrapper.go
@@ -293,8 +293,7 @@ func getBandwidthIdNameMapping(vpcClient *golangsdk.ServiceClient) (map[string]s
 }
 
 func getPublicIpIdNameMapping(vpcClient *golangsdk.ServiceClient, projectId string) (map[string]string, error) {
-	vpcClient.Endpoint = vpcClient.Endpoint + projectId + "/"
-	vpcClient.ResourceBase = vpcClient.Endpoint
+	vpcClient.ResourceBase = vpcClient.ResourceBase + projectId + "/"
 	vpcPageResponse := vpcPublicIps.List(vpcClient, vpcPublicIps.ListOpts{})
 	allPages, err := vpcPageResponse.AllPages()
 	if err != nil {


### PR DESCRIPTION
* instead of overwriting the vpcClient endpoint only the vpcClient resource base will be appended by the project id

fixes #56 