### PR TITLE
Helm Chart: Fix default deployment env vars to allow usage of chart as dependency

### DIFF
--- a/charts/otc-prometheus-exporter/README.md
+++ b/charts/otc-prometheus-exporter/README.md
@@ -18,6 +18,8 @@ To install the chart with the release name otc-prometheus-exporter:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| fullnameOverride | string | `""` |  |
+| nameOverride | string | `""` |  |
 | dashboards.as.enabled | bool | `true` |  |
 | dashboards.bms.enabled | bool | `true` |  |
 | dashboards.cbr.enabled | bool | `true` |  |
@@ -50,7 +52,6 @@ To install the chart with the release name otc-prometheus-exporter:
 | deployment.env.REGION | string | `"eu-de"` |  |
 | deployment.env.WAITDURATION | int | `60` |  |
 | deployment.envFromSecret | object | `{}` |  |
-| deployment.fullnameOverride | string | `""` |  |
 | deployment.health.liveness.path | string | `"/metrics"` |  |
 | deployment.health.liveness.periodSeconds | int | `180` |  |
 | deployment.health.liveness.port | int | `39100` |  |
@@ -62,7 +63,6 @@ To install the chart with the release name otc-prometheus-exporter:
 | deployment.image.repository | string | `"ghcr.io/iits-consulting/otc-prometheus-exporter"` |  |
 | deployment.image.tag | string | `""` |  |
 | deployment.imagePullSecrets | list | `[]` |  |
-| deployment.nameOverride | string | `""` |  |
 | deployment.podAnnotations | object | `{}` |  |
 | deployment.podSecurityContext | string | `nil` |  |
 | deployment.ports.metrics.port | int | `39100` |  |

--- a/charts/otc-prometheus-exporter/templates/deployment.yaml
+++ b/charts/otc-prometheus-exporter/templates/deployment.yaml
@@ -53,10 +53,10 @@ spec:
             - name: {{ printf "%s" $key | replace "." "_" | upper | quote }}
               value: {{ tpl ($value | toString) $ | quote }}
             {{- end }}
-          {{- if .Values.deployment.envSecretName}}
+          {{- if .Values.deployment.envFromSecret}}
           envFrom:
             - secretRef:
-                name: {{.Values.deployment.envSecretName}}
+                name: {{.Values.deployment.envFromSecret}}
           {{- end }}
           ports:
             {{- range $name,$values := .Values.deployment.ports }}

--- a/charts/otc-prometheus-exporter/values.yaml
+++ b/charts/otc-prometheus-exporter/values.yaml
@@ -74,21 +74,21 @@ deployment:
      # failureThreshold: # defaults to 3
      port: 39100
 
-  env:
-    # set the values as required
-    FETCH_RESOURCE_ID_TO_NAME: false
-    WAITDURATION: 60
-    REGION: "eu-de"
-    PORT: 39100
-    OS_USERNAME: "" # Comment this line out or remove if using AK/SK
-    OS_PASSWORD: "" # Comment this line out or remove if using AK/SK
-    OS_PROJECT_ID: "f0f45389d6a947d88c8658fb8e1a1053" # Example f0f45389d6a947d88c8658fb8e1aXXX
-    OS_DOMAIN_NAME:  "OTC-EU-DE-00000000001000058635" # Example OTC-EU-DE-000000000010000....  # This will be ignored when using the AK/SK Auth
+  env: { }
+    # set the values as required as long envFromSecret is not used
+    # FETCH_RESOURCE_ID_TO_NAME: false
+    # WAITDURATION: 60
+    # REGION: "eu-de"
+    # PORT: 39100
+    # OS_USERNAME: "" # Comment this line out or remove if using AK/SK
+    # OS_PASSWORD: "" # Comment this line out or remove if using AK/SK
+    # OS_PROJECT_ID: "f0f45389d6a947d88c8658fb8e1a1053" # Example f0f45389d6a947d88c8658fb8e1aXXX
+    # OS_DOMAIN_NAME:  "OTC-EU-DE-00000000001000058635" # Example OTC-EU-DE-000000000010000....  # This will be ignored when using the AK/SK Auth
     # OS_SECRET_KEY: "SK" 
     # OS_ACCESS_KEY: "AK" 
     # NAMESPACES: # If not set will fetch everything
 
-  #set the secret where to take env from
+  # set the secret where to take env from as long as "env" is not used
   envFromSecret: { }
 
 serviceMonitor:

--- a/charts/otc-prometheus-exporter/values.yaml
+++ b/charts/otc-prometheus-exporter/values.yaml
@@ -1,3 +1,6 @@
+nameOverride: ""
+fullnameOverride: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -28,8 +31,6 @@ deployment:
     tag: ""
 
   imagePullSecrets: [ ]
-  nameOverride: ""
-  fullnameOverride: ""
 
   podAnnotations: { }
 


### PR DESCRIPTION
If this chart is used as a helm dependency, then it is usual for further values to be set via a separate value file. However, as the env variables are already set as an example in the standard values file of this chart, they cannot be removed completely. However, if the env vars are to be used from a secret (envFromSecret), then these values come into conflict with each other. 

This PR comments out the example vars and also fixes an incorrect reference in the deployment template to envFromSecret.
