### PR TITLE
Fix envFromSecret if

### DIFF
--- a/charts/otc-prometheus-exporter/templates/deployment.yaml
+++ b/charts/otc-prometheus-exporter/templates/deployment.yaml
@@ -50,9 +50,10 @@ spec:
             {{- if .Values.deployment.envFromSecret}}
             - secretRef:
                 name: {{.Values.deployment.envFromSecret}}
-            {{- end }}
+            {{- else }}
             - secretRef:
                 name: {{ include "otc-prometheus-exporter.fullname" . }}-env-secrets
+            {{- end }}
           ports:
             {{- range $name,$values := .Values.deployment.ports }}
             - name: {{$name }}


### PR DESCRIPTION
In the current state if you want to use an own secret the default would always still be present preventing the start of the container. 

This fix is to use either an own or the default secret. This Bug was introduced by recent changes.
