### PR TITLE
fix: prometheus alerts - percentage values are 0 to 100, not 0 to 1

### DIFF
--- a/charts/otc-prometheus-exporter/Chart.yaml
+++ b/charts/otc-prometheus-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: otc-prometheus-exporter
 description: Prometheus exporter for Open Telekom Cloud (OTC) metrics
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: 2.0.0

--- a/charts/otc-prometheus-exporter/README.md
+++ b/charts/otc-prometheus-exporter/README.md
@@ -1,6 +1,6 @@
 # otc-prometheus-exporter
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Prometheus exporter for Open Telekom Cloud (OTC) metrics
 

--- a/charts/otc-prometheus-exporter/alerts/elb.yaml
+++ b/charts/otc-prometheus-exporter/alerts/elb.yaml
@@ -1,108 +1,108 @@
 groups:
   - name: elb-http
     rules:
-    - alert: ELBHighHTTPResponseTime
-      annotations:
-        summary: '{{ $labels.loadbalancer }} HTTP response time > 500 ms'
-        description: 'Average Layer 7 response time (m14_l7_rt) for ELB {{ $labels.loadbalancer }} has exceeded 500 ms. Current: {{ $value }} ms'
-      expr: |
-        elb_m14_l7_rt > 500
-      labels:
-        severity: warning
-    - alert: ELBVeryHighHTTPResponseTime
-      annotations:
-        summary: '{{ $labels.loadbalancer }} HTTP response time > 1000 ms'
-        description: 'Average Layer 7 response time (m14_l7_rt) for ELB {{ $labels.loadbalancer }} has exceeded 1000 ms. Current: {{ $value }} ms'
-      expr: |
-        elb_m14_l7_rt > 1000
-      labels:
-        severity: critical
+      - alert: ELBHighHTTPResponseTime
+        annotations:
+          summary: '{{ $labels.loadbalancer }} HTTP response time > 500 ms'
+          description: 'Average Layer 7 response time (m14_l7_rt) for ELB {{ $labels.loadbalancer }} has exceeded 500 ms. Current: {{ $value }} ms'
+        expr: |
+          elb_m14_l7_rt > 500
+        labels:
+          severity: warning
+      - alert: ELBVeryHighHTTPResponseTime
+        annotations:
+          summary: '{{ $labels.loadbalancer }} HTTP response time > 1000 ms'
+          description: 'Average Layer 7 response time (m14_l7_rt) for ELB {{ $labels.loadbalancer }} has exceeded 1000 ms. Current: {{ $value }} ms'
+        expr: |
+          elb_m14_l7_rt > 1000
+        labels:
+          severity: critical
 
   - name: elb-usage
     rules:
-    - alert: ELBHighLayer4ConnectionUsage
-      annotations:
-        summary: '{{ $labels.loadbalancer }} layer 4 connection usage > 80%'
-        description: 'Layer 4 concurrent connections (l4_con_usage) for ELB {{ $labels.loadbalancer }} has exceeded 80%. Current: {{ $value }}%'
-      expr: |
-        elb_l4_con_usage > 0.8
-      labels:
-        severity: warning
-    - alert: ELBHighLayer4InboundBandwidthUsage
-      annotations:
-        summary: '{{ $labels.loadbalancer }} layer 4 inbound bandwidth usage > 80%'
-        description: 'Layer 4 inbound bandwidth (l4_in_bps_usage) for ELB {{ $labels.loadbalancer }} has exceeded 80%. Current: {{ $value }}%'
-      expr: |
-        elb_l4_in_bps_usage > 0.8
-      labels:
-        severity: warning
-    - alert: ELBHighLayer4OutboundBandwidthUsage
-      annotations:
-        summary: '{{ $labels.loadbalancer }} layer 4 outbound bandwidth usage > 80%'
-        description: 'Layer 4 outbound bandwidth (l4_out_bps_usage) for ELB {{ $labels.loadbalancer }} has exceeded 80%. Current: {{ $value }}%'
-      expr: |
-        elb_l4_out_bps_usage > 0.8
-      labels:
-        severity: warning
-    - alert: ELBHighLayer7ConnectionUsage
-      annotations:
-        summary: '{{ $labels.loadbalancer }} layer 7 connection usage > 80%'
-        description: 'Layer 7 concurrent connections (l7_con_usage) for ELB {{ $labels.loadbalancer }} has exceeded 80%. Current: {{ $value }}%'
-      expr: |
-        elb_l7_con_usage > 0.8
-      labels:
-        severity: warning
-    - alert: ELBHighLayer7InboundBandwidthUsage
-      annotations:
-        summary: '{{ $labels.loadbalancer }} layer 7 inbound bandwidth usage > 80%'
-        description: 'Layer 7 inbound bandwidth (l7_in_bps_usage) for ELB {{ $labels.loadbalancer }} has exceeded 80%. Current: {{ $value }}%'
-      expr: |
-        elb_l7_in_bps_usage > 0.8
-      labels:
-        severity: warning
-    - alert: ELBHighLayer7OutboundBandwidthUsage
-      annotations:
-        summary: '{{ $labels.loadbalancer }} layer 7 outbound bandwidth usage > 80%'
-        description: 'Layer 7 outbound bandwidth (l7_out_bps_usage) for ELB {{ $labels.loadbalancer }} has exceeded 80%. Current: {{ $value }}%'
-      expr: |
-        elb_l7_out_bps_usage > 0.8
-      labels:
-        severity: warning
-    - alert: ELBHighLayer7NewConnectionUsage
-      annotations:
-        summary: '{{ $labels.loadbalancer }} layer 7 new connection usage > 80%'
-        description: 'Layer 7 new connection usage (l7_ncps_usage) for ELB {{ $labels.loadbalancer }} has exceeded 80%. Current: {{ $value }}%'
-      expr: |
-        elb_l7_ncps_usage > 0.8
-      labels:
-        severity: warning
+      - alert: ELBHighLayer4ConnectionUsage
+        annotations:
+          summary: '{{ $labels.loadbalancer }} layer 4 connection usage > 80%'
+          description: 'Layer 4 concurrent connections (l4_con_usage) for ELB {{ $labels.loadbalancer }} has exceeded 80%. Current: {{ $value }}%'
+        expr: |
+          elb_l4_con_usage > 80
+        labels:
+          severity: warning
+      - alert: ELBHighLayer4InboundBandwidthUsage
+        annotations:
+          summary: '{{ $labels.loadbalancer }} layer 4 inbound bandwidth usage > 80%'
+          description: 'Layer 4 inbound bandwidth (l4_in_bps_usage) for ELB {{ $labels.loadbalancer }} has exceeded 80%. Current: {{ $value }}%'
+        expr: |
+          elb_l4_in_bps_usage > 80
+        labels:
+          severity: warning
+      - alert: ELBHighLayer4OutboundBandwidthUsage
+        annotations:
+          summary: '{{ $labels.loadbalancer }} layer 4 outbound bandwidth usage > 80%'
+          description: 'Layer 4 outbound bandwidth (l4_out_bps_usage) for ELB {{ $labels.loadbalancer }} has exceeded 80%. Current: {{ $value }}%'
+        expr: |
+          elb_l4_out_bps_usage > 80
+        labels:
+          severity: warning
+      - alert: ELBHighLayer7ConnectionUsage
+        annotations:
+          summary: '{{ $labels.loadbalancer }} layer 7 connection usage > 80%'
+          description: 'Layer 7 concurrent connections (l7_con_usage) for ELB {{ $labels.loadbalancer }} has exceeded 80%. Current: {{ $value }}%'
+        expr: |
+          elb_l7_con_usage > 80
+        labels:
+          severity: warning
+      - alert: ELBHighLayer7InboundBandwidthUsage
+        annotations:
+          summary: '{{ $labels.loadbalancer }} layer 7 inbound bandwidth usage > 80%'
+          description: 'Layer 7 inbound bandwidth (l7_in_bps_usage) for ELB {{ $labels.loadbalancer }} has exceeded 80%. Current: {{ $value }}%'
+        expr: |
+          elb_l7_in_bps_usage > 80
+        labels:
+          severity: warning
+      - alert: ELBHighLayer7OutboundBandwidthUsage
+        annotations:
+          summary: '{{ $labels.loadbalancer }} layer 7 outbound bandwidth usage > 80%'
+          description: 'Layer 7 outbound bandwidth (l7_out_bps_usage) for ELB {{ $labels.loadbalancer }} has exceeded 80%. Current: {{ $value }}%'
+        expr: |
+          elb_l7_out_bps_usage > 80
+        labels:
+          severity: warning
+      - alert: ELBHighLayer7NewConnectionUsage
+        annotations:
+          summary: '{{ $labels.loadbalancer }} layer 7 new connection usage > 80%'
+          description: 'Layer 7 new connection usage (l7_ncps_usage) for ELB {{ $labels.loadbalancer }} has exceeded 80%. Current: {{ $value }}%'
+        expr: |
+          elb_l7_ncps_usage > 80
+        labels:
+          severity: warning
 
   - name: elb-backend-server-health
     rules:
-    - alert: ELBUnhealthyBackendServers
-      annotations:
-        summary: '{{ $labels.loadbalancer }} unhealthy backend servers > 0'
-        description: 'Number of unhealthy backend servers (m9_abnormal_servers) for ELB {{ $labels.loadbalancer }} is > 0. Current: {{ $value }}'
-      expr: |
-        elb_m9_abnormal_servers > 0
-      labels:
-        severity: warning
-    - alert: ELBAllBackendServersUnhealthy
-      annotations:
-        summary: '{{ $labels.loadbalancer }} all backend servers unhealthy'
-        description: 'All backend servers for ELB {{ $labels.loadbalancer }} are unhealthy if m9_abnormal_servers == (m9_abnormal_servers + ma_normal_servers).'
-      expr: |
-        elb_m9_abnormal_servers == (elb_m9_abnormal_servers + elb_ma_normal_servers)
-      labels:
-        severity: critical
+      - alert: ELBUnhealthyBackendServers
+        annotations:
+          summary: '{{ $labels.loadbalancer }} unhealthy backend servers > 0'
+          description: 'Number of unhealthy backend servers (m9_abnormal_servers) for ELB {{ $labels.loadbalancer }} is > 0. Current: {{ $value }}'
+        expr: |
+          elb_m9_abnormal_servers > 0
+        labels:
+          severity: warning
+      - alert: ELBAllBackendServersUnhealthy
+        annotations:
+          summary: '{{ $labels.loadbalancer }} all backend servers unhealthy'
+          description: 'All backend servers for ELB {{ $labels.loadbalancer }} are unhealthy if m9_abnormal_servers == (m9_abnormal_servers + ma_normal_servers).'
+        expr: |
+          elb_m9_abnormal_servers == (elb_m9_abnormal_servers + elb_ma_normal_servers)
+        labels:
+          severity: critical
 
   - name: elb-server-latency
     rules:
-    - alert: ELBHighBackendResponseTime
-      annotations:
-        summary: '{{ $labels.loadbalancer }} backend response time > 1000 ms'
-        description: 'Average backend response time (m17_l7_upstream_rt) for ELB {{ $labels.loadbalancer }} has exceeded 1000 ms. Current: {{ $value }} ms'
-      expr: |
-        elb_m17_l7_upstream_rt > 1000
-      labels:
-        severity: warning
+      - alert: ELBHighBackendResponseTime
+        annotations:
+          summary: '{{ $labels.loadbalancer }} backend response time > 1000 ms'
+          description: 'Average backend response time (m17_l7_upstream_rt) for ELB {{ $labels.loadbalancer }} has exceeded 1000 ms. Current: {{ $value }} ms'
+        expr: |
+          elb_m17_l7_upstream_rt > 1000
+        labels:
+          severity: warning

--- a/charts/otc-prometheus-exporter/alerts/obs.yaml
+++ b/charts/otc-prometheus-exporter/alerts/obs.yaml
@@ -1,54 +1,54 @@
 groups:
   - name: obs-system
     rules:
-    - alert: OBSHighRequestSuccessRateDrop
-      annotations:
-        summary: '{{ $labels.bucket }} OBS request success rate < 95%'
-        description: 'The request success rate for OBS bucket {{ $labels.bucket }} has dropped below 95%. Current: {{ $value }}%'
-      expr: |
-        obs_request_success_rate < 0.95
-      labels:
-        severity: warning
-    - alert: OBSCriticalRequestSuccessRateDrop
-      annotations:
-        summary: '{{ $labels.bucket }} OBS request success rate < 90%'
-        description: 'The request success rate for OBS bucket {{ $labels.bucket }} has dropped below 90%. Current: {{ $value }}%'
-      expr: |
-        obs_request_success_rate < 0.9
-      labels:
-        severity: critical
+      - alert: OBSHighRequestSuccessRateDrop
+        annotations:
+          summary: '{{ $labels.bucket }} OBS request success rate < 95%'
+          description: 'The request success rate for OBS bucket {{ $labels.bucket }} has dropped below 95%. Current: {{ $value }}%'
+        expr: |
+          obs_request_success_rate < 95
+        labels:
+          severity: warning
+      - alert: OBSCriticalRequestSuccessRateDrop
+        annotations:
+          summary: '{{ $labels.bucket }} OBS request success rate < 90%'
+          description: 'The request success rate for OBS bucket {{ $labels.bucket }} has dropped below 90%. Current: {{ $value }}%'
+        expr: |
+          obs_request_success_rate < 90
+        labels:
+          severity: critical
 
   - name: obs-latency
     rules:
-    - alert: OBSHighAverageRequestLatency
-      annotations:
-        summary: '{{ $labels.bucket }} OBS average request latency high'
-        description: 'Average request latency for OBS bucket {{ $labels.bucket }} has exceeded 500 ms. Current: {{ $value }} ms'
-      expr: |
-        obs_total_request_latency > 500
-      labels:
-        severity: warning
-    - alert: OBSVeryHighAverageRequestLatency
-      annotations:
-        summary: '{{ $labels.bucket }} OBS average request latency very high'
-        description: 'Average request latency for OBS bucket {{ $labels.bucket }} has exceeded 1000 ms. Current: {{ $value }} ms'
-      expr: |
-        obs_total_request_latency > 1000
-      labels:
-        severity: critical
-    - alert: OBSHighFirstByteLatency
-      annotations:
-        summary: '{{ $labels.bucket }} OBS first-byte latency high'
-        description: 'First byte latency for OBS bucket {{ $labels.bucket }} has exceeded 200 ms. Current: {{ $value }} ms'
-      expr: |
-        obs_first_byte_latency > 200
-      labels:
-        severity: warning
-    - alert: OBSCriticalFirstByteLatency
-      annotations:
-        summary: '{{ $labels.bucket }} OBS first-byte latency critical'
-        description: 'First byte latency for OBS bucket {{ $labels.bucket }} has exceeded 500 ms. Current: {{ $value }} ms'
-      expr: |
-        obs_first_byte_latency > 500
-      labels:
-        severity: critical
+      - alert: OBSHighAverageRequestLatency
+        annotations:
+          summary: '{{ $labels.bucket }} OBS average request latency high'
+          description: 'Average request latency for OBS bucket {{ $labels.bucket }} has exceeded 500 ms. Current: {{ $value }} ms'
+        expr: |
+          obs_total_request_latency > 500
+        labels:
+          severity: warning
+      - alert: OBSVeryHighAverageRequestLatency
+        annotations:
+          summary: '{{ $labels.bucket }} OBS average request latency very high'
+          description: 'Average request latency for OBS bucket {{ $labels.bucket }} has exceeded 1000 ms. Current: {{ $value }} ms'
+        expr: |
+          obs_total_request_latency > 1000
+        labels:
+          severity: critical
+      - alert: OBSHighFirstByteLatency
+        annotations:
+          summary: '{{ $labels.bucket }} OBS first-byte latency high'
+          description: 'First byte latency for OBS bucket {{ $labels.bucket }} has exceeded 200 ms. Current: {{ $value }} ms'
+        expr: |
+          obs_first_byte_latency > 200
+        labels:
+          severity: warning
+      - alert: OBSCriticalFirstByteLatency
+        annotations:
+          summary: '{{ $labels.bucket }} OBS first-byte latency critical'
+          description: 'First byte latency for OBS bucket {{ $labels.bucket }} has exceeded 500 ms. Current: {{ $value }} ms'
+        expr: |
+          obs_first_byte_latency > 500
+        labels:
+          severity: critical

--- a/charts/otc-prometheus-exporter/alerts/rds.yaml
+++ b/charts/otc-prometheus-exporter/alerts/rds.yaml
@@ -1,89 +1,89 @@
 groups:
   - name: postgresql-system
     rules:
-    - alert: PostgreSQLHighCPUUtilization
-      annotations:
-        summary: '{{ $labels.instance }} CPU > 80%'
-        description: 'CPU utilization for PostgreSQL instance {{ $labels.instance }} has been above 80%. Current: {{ $value }}%'
-      expr: |
-        rds_rds001_cpu_util > 0.8
-      labels:
-        severity: warning
-    - alert: PostgreSQLVeryHighCPUUtilization
-      annotations:
-        summary: '{{ $labels.instance }} CPU > 90%'
-        description: 'CPU utilization for PostgreSQL instance {{ $labels.instance }} has been above 90%. Current: {{ $value }}%'
-      expr: |
-        rds_rds001_cpu_util > 0.9
-      labels:
-        severity: critical
-    - alert: PostgreSQLHighMemoryUtilization
-      annotations:
-        summary: '{{ $labels.instance }} Memory > 80%'
-        description: 'Memory utilization for PostgreSQL instance {{ $labels.instance }} has exceeded 80%. Current: {{ $value }}%'
-      expr: |
-        rds_rds002_mem_util > 0.8
-      labels:
-        severity: warning
-    - alert: PostgreSQLVeryHighMemoryUtilization
-      annotations:
-        summary: '{{ $labels.instance }} Memory > 90%'
-        description: 'Memory utilization for PostgreSQL instance {{ $labels.instance }} has exceeded 90%. Current: {{ $value }}%'
-      expr: |
-        rds_rds002_mem_util > 0.9
-      labels:
-        severity: critical
-    - alert: PostgreSQLHighDiskUtilization
-      annotations:
-        summary: '{{ $labels.instance }} Disk > 80%'
-        description: 'Disk usage for PostgreSQL instance {{ $labels.instance }} has been above 80%. Current: {{ $value }}%'
-      expr: |
-        rds_rds039_disk_util > 0.8
-      labels:
-        severity: warning
-    - alert: PostgreSQLVeryHighDiskUtilization
-      annotations:
-        summary: '{{ $labels.instance }} Disk > 90%'
-        description: 'Disk usage for PostgreSQL instance {{ $labels.instance }} has been above 90%. Current: {{ $value }}%'
-      expr: |
-        rds_rds039_disk_util > 0.9
-      labels:
-        severity: critical
+      - alert: PostgreSQLHighCPUUtilization
+        annotations:
+          summary: '{{ $labels.instance }} CPU > 80%'
+          description: 'CPU utilization for PostgreSQL instance {{ $labels.instance }} has been above 80%. Current: {{ $value }}%'
+        expr: |
+          rds_rds001_cpu_util > 80
+        labels:
+          severity: warning
+      - alert: PostgreSQLVeryHighCPUUtilization
+        annotations:
+          summary: '{{ $labels.instance }} CPU > 90%'
+          description: 'CPU utilization for PostgreSQL instance {{ $labels.instance }} has been above 90%. Current: {{ $value }}%'
+        expr: |
+          rds_rds001_cpu_util > 90
+        labels:
+          severity: critical
+      - alert: PostgreSQLHighMemoryUtilization
+        annotations:
+          summary: '{{ $labels.instance }} Memory > 80%'
+          description: 'Memory utilization for PostgreSQL instance {{ $labels.instance }} has exceeded 80%. Current: {{ $value }}%'
+        expr: |
+          rds_rds002_mem_util > 80
+        labels:
+          severity: warning
+      - alert: PostgreSQLVeryHighMemoryUtilization
+        annotations:
+          summary: '{{ $labels.instance }} Memory > 90%'
+          description: 'Memory utilization for PostgreSQL instance {{ $labels.instance }} has exceeded 90%. Current: {{ $value }}%'
+        expr: |
+          rds_rds002_mem_util > 90
+        labels:
+          severity: critical
+      - alert: PostgreSQLHighDiskUtilization
+        annotations:
+          summary: '{{ $labels.instance }} Disk > 80%'
+          description: 'Disk usage for PostgreSQL instance {{ $labels.instance }} has been above 80%. Current: {{ $value }}%'
+        expr: |
+          rds_rds039_disk_util > 80
+        labels:
+          severity: warning
+      - alert: PostgreSQLVeryHighDiskUtilization
+        annotations:
+          summary: '{{ $labels.instance }} Disk > 90%'
+          description: 'Disk usage for PostgreSQL instance {{ $labels.instance }} has been above 90%. Current: {{ $value }}%'
+        expr: |
+          rds_rds039_disk_util > 90
+        labels:
+          severity: critical
 
   - name: postgresql-storage-conditions
     rules:
-    - alert: PostgreSQLDiskSpaceAlmostFull
-      annotations:
-        summary: '{{ $labels.instance }} Disk > 90% of total'
-        description: 'Disk used ({{ $value | humanizePercentage }}) of total capacity for PostgreSQL instance {{ $labels.instance }} has exceeded 90%.'
-      expr: |
-        (rds_rds048_disk_used_size / rds_rds047_disk_total_size) > 0.9
-      labels:
-        severity: warning
-    - alert: PostgreSQLDiskSpaceCriticallyLow
-      annotations:
-        summary: '{{ $labels.instance }} Disk > 95% of total'
-        description: 'Disk used ({{ $value | humanizePercentage }}) of total capacity for PostgreSQL instance {{ $labels.instance }} has exceeded 95%.'
-      expr: |
-        (rds_rds048_disk_used_size / rds_rds047_disk_total_size) > 0.95
-      labels:
-        severity: critical
+      - alert: PostgreSQLDiskSpaceAlmostFull
+        annotations:
+          summary: '{{ $labels.instance }} Disk > 90% of total'
+          description: 'Disk used ({{ $value | humanizePercentage }}) of total capacity for PostgreSQL instance {{ $labels.instance }} has exceeded 90%.'
+        expr: |
+          (rds_rds048_disk_used_size / rds_rds047_disk_total_size) > 0.9
+        labels:
+          severity: warning
+      - alert: PostgreSQLDiskSpaceCriticallyLow
+        annotations:
+          summary: '{{ $labels.instance }} Disk > 95% of total'
+          description: 'Disk used ({{ $value | humanizePercentage }}) of total capacity for PostgreSQL instance {{ $labels.instance }} has exceeded 95%.'
+        expr: |
+          (rds_rds048_disk_used_size / rds_rds047_disk_total_size) > 0.95
+        labels:
+          severity: critical
 
   - name: postgresql-db-connection-usage
     rules:
-    - alert: PostgreSQLHighConnectionUsage
-      annotations:
-        summary: '{{ $labels.instance }} Connections > 80%'
-        description: 'Connection usage for PostgreSQL instance {{ $labels.instance }} has been above 80%. Current: {{ $value }}% of max connections'
-      expr: |
-        rds_rds083_conn_usage > 0.8
-      labels:
-        severity: warning
-    - alert: PostgreSQLVeryHighConnectionUsage
-      annotations:
-        summary: '{{ $labels.instance }} Connections > 90%'
-        description: 'Connection usage for PostgreSQL instance {{ $labels.instance }} has been above 90%. Current: {{ $value }}% of max connections'
-      expr: |
-        rds_rds083_conn_usage > 0.9
-      labels:
-        severity: critical
+      - alert: PostgreSQLHighConnectionUsage
+        annotations:
+          summary: '{{ $labels.instance }} Connections > 80%'
+          description: 'Connection usage for PostgreSQL instance {{ $labels.instance }} has been above 80%. Current: {{ $value }}% of max connections'
+        expr: |
+          rds_rds083_conn_usage > 80
+        labels:
+          severity: warning
+      - alert: PostgreSQLVeryHighConnectionUsage
+        annotations:
+          summary: '{{ $labels.instance }} Connections > 90%'
+          description: 'Connection usage for PostgreSQL instance {{ $labels.instance }} has been above 90%. Current: {{ $value }}% of max connections'
+        expr: |
+          rds_rds083_conn_usage > 90
+        labels:
+          severity: critical

--- a/charts/otc-prometheus-exporter/alerts/unittests/elb_test.yaml
+++ b/charts/otc-prometheus-exporter/alerts/unittests/elb_test.yaml
@@ -34,7 +34,7 @@ tests:
 
   - input_series:
       - series: 'elb_l4_con_usage{loadbalancer="elb1"}'
-        values: '0.85'
+        values: '85'
     alert_rule_test:
       - eval_time: 1m
         alertname: ELBHighLayer4ConnectionUsage
@@ -48,7 +48,7 @@ tests:
 
   - input_series:
       - series: 'elb_l4_in_bps_usage{loadbalancer="elb1"}'
-        values: '0.85'
+        values: '85'
     alert_rule_test:
       - eval_time: 1m
         alertname: ELBHighLayer4InboundBandwidthUsage
@@ -62,7 +62,7 @@ tests:
 
   - input_series:
       - series: 'elb_l4_out_bps_usage{loadbalancer="elb1"}'
-        values: '0.85'
+        values: '85'
     alert_rule_test:
       - eval_time: 1m
         alertname: ELBHighLayer4OutboundBandwidthUsage
@@ -76,7 +76,7 @@ tests:
 
   - input_series:
       - series: 'elb_l7_con_usage{loadbalancer="elb1"}'
-        values: '0.85'
+        values: '85'
     alert_rule_test:
       - eval_time: 1m
         alertname: ELBHighLayer7ConnectionUsage
@@ -90,7 +90,7 @@ tests:
 
   - input_series:
       - series: 'elb_l7_in_bps_usage{loadbalancer="elb1"}'
-        values: '0.85'
+        values: '85'
     alert_rule_test:
       - eval_time: 1m
         alertname: ELBHighLayer7InboundBandwidthUsage
@@ -104,7 +104,7 @@ tests:
 
   - input_series:
       - series: 'elb_l7_out_bps_usage{loadbalancer="elb1"}'
-        values: '0.85'
+        values: '85'
     alert_rule_test:
       - eval_time: 1m
         alertname: ELBHighLayer7OutboundBandwidthUsage
@@ -118,7 +118,7 @@ tests:
 
   - input_series:
       - series: 'elb_l7_ncps_usage{loadbalancer="elb1"}'
-        values: '0.85'
+        values: '85'
     alert_rule_test:
       - eval_time: 1m
         alertname: ELBHighLayer7NewConnectionUsage

--- a/charts/otc-prometheus-exporter/alerts/unittests/obs_test.yaml
+++ b/charts/otc-prometheus-exporter/alerts/unittests/obs_test.yaml
@@ -6,7 +6,7 @@ evaluation_interval: 1m
 tests:
   - input_series:
       - series: 'obs_request_success_rate{bucket="bucket1"}'
-        values: '0.94'
+        values: '94'
     alert_rule_test:
       - eval_time: 1m
         alertname: OBSHighRequestSuccessRateDrop
@@ -20,7 +20,7 @@ tests:
 
   - input_series:
       - series: 'obs_request_success_rate{bucket="bucket1"}'
-        values: '0.85'
+        values: '85'
     alert_rule_test:
       - eval_time: 1m
         alertname: OBSCriticalRequestSuccessRateDrop

--- a/charts/otc-prometheus-exporter/alerts/unittests/postgresql_test.yaml
+++ b/charts/otc-prometheus-exporter/alerts/unittests/postgresql_test.yaml
@@ -6,7 +6,7 @@ evaluation_interval: 1m
 tests:
   - input_series:
       - series: 'rds_rds001_cpu_util{instance="db1"}'
-        values: '0.85'
+        values: '85'
     alert_rule_test:
       - eval_time: 1m
         alertname: PostgreSQLHighCPUUtilization
@@ -20,7 +20,7 @@ tests:
 
   - input_series:
       - series: 'rds_rds001_cpu_util{instance="db1"}'
-        values: '0.95'
+        values: '95'
     alert_rule_test:
       - eval_time: 1m
         alertname: PostgreSQLVeryHighCPUUtilization
@@ -34,7 +34,7 @@ tests:
 
   - input_series:
       - series: 'rds_rds002_mem_util{instance="db1"}'
-        values: '0.85'
+        values: '85'
     alert_rule_test:
       - eval_time: 1m
         alertname: PostgreSQLHighMemoryUtilization
@@ -48,7 +48,7 @@ tests:
 
   - input_series:
       - series: 'rds_rds002_mem_util{instance="db1"}'
-        values: '0.95'
+        values: '95'
     alert_rule_test:
       - eval_time: 1m
         alertname: PostgreSQLVeryHighMemoryUtilization
@@ -62,7 +62,7 @@ tests:
 
   - input_series:
       - series: 'rds_rds039_disk_util{instance="db1"}'
-        values: '0.85'
+        values: '85'
     alert_rule_test:
       - eval_time: 1m
         alertname: PostgreSQLHighDiskUtilization
@@ -76,7 +76,7 @@ tests:
 
   - input_series:
       - series: 'rds_rds039_disk_util{instance="db1"}'
-        values: '0.95'
+        values: '95'
     alert_rule_test:
       - eval_time: 1m
         alertname: PostgreSQLVeryHighDiskUtilization
@@ -122,7 +122,7 @@ tests:
 
   - input_series:
       - series: 'rds_rds083_conn_usage{instance="db1"}'
-        values: '0.85'
+        values: '85'
     alert_rule_test:
       - eval_time: 1m
         alertname: PostgreSQLHighConnectionUsage
@@ -136,7 +136,7 @@ tests:
 
   - input_series:
       - series: 'rds_rds083_conn_usage{instance="db1"}'
-        values: '0.95'
+        values: '95'
     alert_rule_test:
       - eval_time: 1m
         alertname: PostgreSQLVeryHighConnectionUsage


### PR DESCRIPTION
As title describes alerts trigger when the values are >0.8 or similar, but actual values returned from OTC are 0-100.
Causing alerts to permanently firing.