### PR TITLE
feat: Experimental Swiss OTC (eu-ch2) support + EVS enrichment 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ Temporary Items
 dist/
 .DS_Store
 .vscode/launch.json
+.superpowers/

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Basic hypervisor-level metrics (CPU utilization, network traffic) are available 
 The Object Storage Service (OBS) metrics have some unique considerations:
 
 1. **Global Project ID Requirement**: Unlike other services OBS is a global service. This means you need a global project ID to gather OBS metrics.
-   The supported projects are `eu-de` and `eu-nl`.
+   The supported projects are `eu-de`, `eu-nl`, and `eu-ch2` (experimental).
 2. **Limitation on Project Scoped Metrics**: OBS metrics cannot be collected with project scoped metrics since a global project ID is needed, which transcends individual project scopes.
 
 ## Requirements
@@ -127,7 +127,7 @@ Assign the **Tenant Guest** role at both **global** and **regional project** sco
 
 CES-only namespaces (WAF, OBS, GaussDB, GaussDBv5, NoSQL, VPN) need **no additional policies** beyond CES ReadOnlyAccess.
 
-All policies must be assigned at the **regional project** scope for the relevant region (`eu-de` or `eu-nl`).
+All policies must be assigned at the **regional project** scope for the relevant region (`eu-de`, `eu-nl`, or `eu-ch2` (experimental)).
 
 ## Usage & Configuration
 
@@ -142,7 +142,7 @@ All policies must be assigned at the **regional project** scope for the relevant
 | `OS_PROJECT_ID`        | -       | **Required** OTC project ID                                                                  |
 | `OS_DOMAIN_NAME`       | -       | **Required** OTC domain name / tenant ID                                                     |
 | `OS_REGION_PROJECT_ID` | -       | Region-level project ID for global services (OBS). Auto-discovered if not set.               |
-| `REGION`               | `eu-de` | OTC region (`eu-de` or `eu-nl`)                                                              |
+| `REGION`               | `eu-de` | OTC region (`eu-de`, `eu-nl`, or `eu-ch2` — see note below)                                  |
 | `PORT`                 | `39100` | HTTP server port                                                                             |
 | `LOG_LEVEL`            | `INFO`  | Log level (`DEBUG`, `INFO`, `WARN`, `ERROR`)                                                 |
 | `REQUEST_TIMEOUT`      | `10`    | HTTP request timeout in seconds for OTC API calls                                            |
@@ -152,6 +152,8 @@ All policies must be assigned at the **regional project** scope for the relevant
 | `CES_LOOKBACK`         | `10`    | CES lookback window in minutes (how far back to query for datapoints)                        |
 | `AOM_BATCH_SIZE`       | `20`    | Max metrics per AOM data API request                                                         |
 | `AOM_CONCURRENCY`      | `5`     | Max concurrent AOM API calls per scrape                                                      |
+
+> **Swiss OTC (`eu-ch2`) — experimental:** Support for the Swiss Open Telekom Cloud is experimental. The Swiss service catalog is smaller than eu-de/eu-nl; the following namespaces are **not available** there and should not be configured as scrape targets: `SYS.DMS`, `SYS.DDS`, `SYS.DCS`, `SYS.DWS`, `SYS.ES`, `SYS.SFS`, `SYS.DCAAS`, `SYS.BMS`.
 
 *Either username+password or access-key+secret-key is required (mutually exclusive).
 

--- a/charts/otc-prometheus-exporter/Chart.yaml
+++ b/charts/otc-prometheus-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: otc-prometheus-exporter
 description: Prometheus exporter for Open Telekom Cloud (OTC) metrics
 type: application
-version: 2.0.1
-appVersion: 2.0.1
+version: 2.1.0
+appVersion: 2.1.0

--- a/charts/otc-prometheus-exporter/README.md
+++ b/charts/otc-prometheus-exporter/README.md
@@ -1,6 +1,6 @@
 # otc-prometheus-exporter
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Prometheus exporter for Open Telekom Cloud (OTC) metrics
 

--- a/charts/otc-prometheus-exporter/values.yaml
+++ b/charts/otc-prometheus-exporter/values.yaml
@@ -80,7 +80,7 @@ deployment:
   # Credentials should be set via envFromSecret in production.
   env:
     # -- Authentication (required — pick one method)
-    # REGION: "eu-de"                # OTC region: "eu-de" or "eu-nl"
+    # REGION: "eu-de"                # OTC region: "eu-de", "eu-nl", or "eu-ch2" (Swiss OTC, experimental)
     # OS_PROJECT_ID: ""              # OTC project ID (always required)
     #
     # Option A: Username/password

--- a/main.go
+++ b/main.go
@@ -144,7 +144,7 @@ func main() {
 	}
 
 	rootCmd.Flags().Uint16VarP(&port, "port", "", 39100, "Port on which metrics are served")
-	rootCmd.Flags().StringVarP(&region, "region", "r", "eu-de", "OTC region")
+	rootCmd.Flags().StringVarP(&region, "region", "r", "eu-de", "OTC region: eu-de, eu-nl, or eu-ch2 (Swiss OTC, experimental)")
 	rootCmd.Flags().StringVarP(&username, "os-username", "u", "", "OTC username (user/password auth)")
 	rootCmd.Flags().StringVarP(&password, "os-password", "p", "", "OTC password (user/password auth)")
 	rootCmd.Flags().StringVarP(&accessKey, "access-key", "", "", "OTC access key (AK/SK auth)")

--- a/otcclient/auth.go
+++ b/otcclient/auth.go
@@ -24,9 +24,10 @@ type Config struct {
 }
 
 func validateConfig(cfg Config) error {
-	// Region must be eu-de or eu-nl.
-	if cfg.Region != "eu-de" && cfg.Region != "eu-nl" {
-		return fmt.Errorf("otcclient: invalid region %q, must be \"eu-de\" or \"eu-nl\"", cfg.Region)
+	// Region must be eu-de, eu-nl, or eu-ch2 (Swiss OTC, experimental).
+	validRegions := map[string]bool{"eu-de": true, "eu-nl": true, "eu-ch2": true}
+	if !validRegions[cfg.Region] {
+		return fmt.Errorf("otcclient: invalid region %q, must be \"eu-de\", \"eu-nl\", or \"eu-ch2\"", cfg.Region)
 	}
 
 	// ProjectID is always required.
@@ -63,6 +64,10 @@ func validateConfig(cfg Config) error {
 }
 
 func iamEndpoint(region string) string {
+	// The Swiss OTC uses an irregular public IAM hostname.
+	if region == "eu-ch2" {
+		return "https://iam-pub.eu-ch2.sc.otc.t-systems.com/v3"
+	}
 	return fmt.Sprintf("https://iam.%s.otc.t-systems.com/v3", region)
 }
 

--- a/otcclient/client_test.go
+++ b/otcclient/client_test.go
@@ -169,3 +169,19 @@ func TestIamEndpoint(t *testing.T) {
 		t.Fatalf("iamEndpoint(eu-de) = %q, want %q", got, want)
 	}
 }
+
+func TestValidateConfigAcceptsSwissRegion(t *testing.T) {
+	cfg := validUserPassConfig()
+	cfg.Region = "eu-ch2"
+	if err := validateConfig(cfg); err != nil {
+		t.Fatalf("expected eu-ch2 config to pass validation, got: %s", err)
+	}
+}
+
+func TestIamEndpointSwiss(t *testing.T) {
+	got := iamEndpoint("eu-ch2")
+	want := "https://iam-pub.eu-ch2.sc.otc.t-systems.com/v3"
+	if got != want {
+		t.Fatalf("iamEndpoint(eu-ch2) = %q, want %q", got, want)
+	}
+}

--- a/otcclient/services.go
+++ b/otcclient/services.go
@@ -105,9 +105,12 @@ func (c *Client) NetworkV1() (*golangsdk.ServiceClient, error) {
 	})
 }
 
-func (c *Client) BlockStorageV3() (*golangsdk.ServiceClient, error) {
+// BlockStorageV2 returns a v2 block storage client. The EVS-specific
+// cloudvolumes API is only published under /v2/{project_id}; the v3
+// endpoint rejects it with APIGW.0101 in all regions.
+func (c *Client) BlockStorageV2() (*golangsdk.ServiceClient, error) {
 	return c.cache.getOrCreate("block", func() (*golangsdk.ServiceClient, error) {
-		return openstack.NewBlockStorageV3(c.provider, c.endpointOpts())
+		return openstack.NewBlockStorageV2(c.provider, c.endpointOpts())
 	})
 }
 

--- a/provider/evs.go
+++ b/provider/evs.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"strings"
 
 	evsVolumes "github.com/opentelekomcloud/gophertelekomcloud/openstack/evs/v2/cloudvolumes"
 	dto "github.com/prometheus/client_model/go"
@@ -17,7 +18,7 @@ func (p *EVSProvider) Namespace() string { return "SYS.EVS" }
 
 func (p *EVSProvider) Collect(ctx context.Context, client *otcclient.Client) ([]*dto.MetricFamily, error) {
 	return CollectWithEnrichment(ctx, client, "SYS.EVS", func(ctx context.Context, client *otcclient.Client) (*EnrichResult, error) {
-		blockClient, err := client.BlockStorageV3()
+		blockClient, err := client.BlockStorageV2()
 		if err != nil {
 			return nil, err
 		}
@@ -33,10 +34,16 @@ func (p *EVSProvider) Collect(ctx context.Context, client *otcclient.Client) ([]
 }
 
 // buildEVSNameMap creates a mapping from EVS volume ID to volume name.
+// CES reports disk metrics with resource_id "{server_id}-{device}" (e.g.
+// "server-1-vdb"), so attachment-based keys are added as well.
 func buildEVSNameMap(volumes []evsVolumes.Volume) map[string]string {
 	m := make(map[string]string, len(volumes))
 	for _, v := range volumes {
 		m[v.ID] = v.Name
+		for _, a := range v.Attachments {
+			device := strings.TrimPrefix(a.Device, "/dev/")
+			m[a.ServerID+"-"+device] = v.Name
+		}
 	}
 	return m
 }

--- a/provider/evs_test.go
+++ b/provider/evs_test.go
@@ -67,3 +67,27 @@ func TestBuildEVSNameMap(t *testing.T) {
 		t.Errorf("expected evs-001 -> %q, got %q", "data-disk-1", nameMap["evs-001"])
 	}
 }
+
+// CES reports EVS disk metrics with resource_id "{server_id}-{device}" (e.g.
+// "server-1-vdb"), not the volume ID, so the name map must also key by
+// attachment.
+func TestBuildEVSNameMapAttachmentKeys(t *testing.T) {
+	volumes := []evsVolumes.Volume{
+		{
+			ID:   "evs-001",
+			Name: "data-disk-1",
+			Attachments: []evsVolumes.Attachment{
+				{ServerID: "server-1", Device: "/dev/vdb"},
+			},
+		},
+	}
+
+	nameMap := buildEVSNameMap(volumes)
+
+	if nameMap["server-1-vdb"] != "data-disk-1" {
+		t.Errorf("expected server-1-vdb -> %q, got %q", "data-disk-1", nameMap["server-1-vdb"])
+	}
+	if nameMap["evs-001"] != "data-disk-1" {
+		t.Errorf("expected volume ID key to remain, got %q", nameMap["evs-001"])
+	}
+}


### PR DESCRIPTION
### Swiss OTC (experimental)                                                                                                                                                                                                                                                                                                                                                                                                                            
  - Accept region `eu-ch2` and use its irregular IAM endpoint `https://iam-pub.eu-ch2.sc.otc.t-systems.com/v3`. All other service endpoints are  catalog-discovered, so no further code changes were needed (AOM derivation and region-project discovery work unchanged). 
 - Docs (README, `--region` help, Helm values) label eu-ch2 as **experimental** and list namespaces not available there: SYS.DMS, SYS.DDS, SYS.DCS, SYS.DWS, SYS.ES, SYS.SFS, SYS.DCAAS, SYS.BMS.                                                                                                                                                                                                                                                                                                                                                                                                                                   
  - Live-verified against a Swiss tenant: AK/SK auth, automatic region-project discovery, CES metrics with enrichment (SYS.ECS/EVS/ALARM), AOM endpoint reachable, graceful degradation for absent services.                                                                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                                          
  ### EVS enrichment fix (all regions, found during verification)                                                                                                                                                                                                                                                                                                                                                                                         
  EVS name enrichment was silently broken everywhere:                                                                                                                                                                                                                                                                                                                                                                                                     
  1. The `cloudvolumes` listing API is only published under `/v2/{project_id}`; the `volumev3` catalog endpoint rejects it with `APIGW.0101` (verified authenticated on both eu-de and eu-ch2). Switched to `NewBlockStorageV2`.                                                                                                                                                                                                                                                                                                                                                                                             
  2. CES reports EVS disk metrics keyed by `{server_id}-{device}` (e.g. `…-vdb`), which  never matched the volume-ID-keyed name map. The map now also contains attachment-based keys.                                                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                                          
  Verified live on eu-de and eu-ch2: previously all EVS `resource_name` labels were empty, now every metric carries the volume name.